### PR TITLE
for jsonmodels 2.1.5 init super before setattr

### DIFF
--- a/src/tinydb_jsonorm/models.py
+++ b/src/tinydb_jsonorm/models.py
@@ -42,13 +42,13 @@ class TinyJsonModel(Model):
     _cuid = fields.StringField()
 
     def __init__(self, eid=None, *args, **kwargs):
+        super(TinyJsonModel, self).__init__(*args, **kwargs)
         # When eid is informed we consider as existent record in the database
         if eid is not None:
             self.eid = eid
         else:
             # Only generate cuid for new record objects eid == None
             self._cuid = uuidgen.cuid()
-        super(TinyJsonModel, self).__init__(*args, **kwargs)
 
     @property
     def id(self):


### PR DESCRIPTION
Since JsonModels 2.1.5, jsonmodels.fields.BaseFields request in __set__ method the attribute _cache_key created by constructor in jsonmodels.models.Base.

So _cache_key must be available before set _cuuid in TinyJsonModel constructor.